### PR TITLE
use a path specific meta tag

### DIFF
--- a/add-to-go.pkgs.sh
+++ b/add-to-go.pkgs.sh
@@ -23,7 +23,7 @@ for pkg in "$@"; do
 	) >> "${redirects}"
 
 	cat > "content/golang/${meta}" <<!
-<html><head><meta name="go-import" content="cloudeng.io git https://github.com/cloudengio/${repo}"/></head></html>
+<html><head><meta name="go-import" content="cloudeng.io/${path} git https://github.com/cloudengio/${repo}"/></head></html>
 !
 	git add "content/golang/${meta}"
 done

--- a/content/golang/go.meta
+++ b/content/golang/go.meta
@@ -1,1 +1,1 @@
-<html><head><meta name="go-import" content="cloudeng.io git https://github.com/cloudengio/go.gotools"/></head></html>
+<html><head><meta name="go-import" content="cloudeng.io/go git https://github.com/cloudengio/go.gotools"/></head></html>


### PR DESCRIPTION
that is, set the content to cloudeng.io/<path> to point to the specific repo and hopefully avoid go get fetching cloudeng.io?go-get-1 whose meta file points to a different repo than the one for cloudeng.io/go
