### PR TITLE
use specific meta tag for all go.pkgs modules

### DIFF
--- a/content/golang/cmdutil.meta
+++ b/content/golang/cmdutil.meta
@@ -1,1 +1,1 @@
-<html><head><meta name="go-import" content="cloudeng.io git https://github.com/cloudengio/go.pkgs"/></head></html>
+<html><head><meta name="go-import" content="cloudeng.io/cmdutil git https://github.com/cloudengio/go.pkgs"/></head></html>

--- a/content/golang/errors.meta
+++ b/content/golang/errors.meta
@@ -1,1 +1,1 @@
-<html><head><meta name="go-import" content="cloudeng.io git https://github.com/cloudengio/go.pkgs"/></head></html>
+<html><head><meta name="go-import" content="cloudeng.io/errors git https://github.com/cloudengio/go.pkgs"/></head></html>

--- a/content/golang/path.meta
+++ b/content/golang/path.meta
@@ -1,1 +1,1 @@
-<html><head><meta name="go-import" content="cloudeng.io git https://github.com/cloudengio/go.pkgs"/></head></html>
+<html><head><meta name="go-import" content="cloudeng.io/path git https://github.com/cloudengio/go.pkgs"/></head></html>

--- a/content/golang/sync.meta
+++ b/content/golang/sync.meta
@@ -1,1 +1,1 @@
-<html><head><meta name="go-import" content="cloudeng.io git https://github.com/cloudengio/go.pkgs"/></head></html>
+<html><head><meta name="go-import" content="cloudeng.io/sync git https://github.com/cloudengio/go.pkgs"/></head></html>

--- a/content/golang/text.meta
+++ b/content/golang/text.meta
@@ -1,1 +1,1 @@
-<html><head><meta name="go-import" content="cloudeng.io git https://github.com/cloudengio/go.pkgs"/></head></html>
+<html><head><meta name="go-import" content="cloudeng.io/text git https://github.com/cloudengio/go.pkgs"/></head></html>


### PR DESCRIPTION
Same as #11 but now for all the other packages. This will avoid calling cloudeng.io?go-get=1 for all of these packages.