### PR TITLE
undo redirect changes for go.pkgs

### DIFF
--- a/content/golang/cmdutil.meta
+++ b/content/golang/cmdutil.meta
@@ -1,1 +1,1 @@
-<html><head><meta name="go-import" content="cloudeng.io/cmdutil git https://github.com/cloudengio/go.pkgs"/></head></html>
+<html><head><meta name="go-import" content="cloudeng.io git https://github.com/cloudengio/go.pkgs"/></head></html>

--- a/content/golang/errors.meta
+++ b/content/golang/errors.meta
@@ -1,1 +1,1 @@
-<html><head><meta name="go-import" content="cloudeng.io/errors git https://github.com/cloudengio/go.pkgs"/></head></html>
+<html><head><meta name="go-import" content="cloudeng.io git https://github.com/cloudengio/go.pkgs"/></head></html>

--- a/content/golang/path.meta
+++ b/content/golang/path.meta
@@ -1,1 +1,1 @@
-<html><head><meta name="go-import" content="cloudeng.io/path git https://github.com/cloudengio/go.pkgs"/></head></html>
+<html><head><meta name="go-import" content="cloudeng.io git https://github.com/cloudengio/go.pkgs"/></head></html>

--- a/content/golang/sync.meta
+++ b/content/golang/sync.meta
@@ -1,1 +1,1 @@
-<html><head><meta name="go-import" content="cloudeng.io/sync git https://github.com/cloudengio/go.pkgs"/></head></html>
+<html><head><meta name="go-import" content="cloudeng.io git https://github.com/cloudengio/go.pkgs"/></head></html>

--- a/content/golang/text.meta
+++ b/content/golang/text.meta
@@ -1,1 +1,1 @@
-<html><head><meta name="go-import" content="cloudeng.io/text git https://github.com/cloudengio/go.pkgs"/></head></html>
+<html><head><meta name="go-import" content="cloudeng.io git https://github.com/cloudengio/go.pkgs"/></head></html>


### PR DESCRIPTION
I misunderstood how go get works for submodules and the cloudeng.io/{errors, text}/... submodule need the content field in the metatag to point to cloudeng.io and not couldeng.io/errors in order for the module specific tags (e.g errors/v0.0.6) to be recognised.